### PR TITLE
Replace sha256Prf in idxcrypt.cpp line 782 with *pPrf

### DIFF
--- a/idxcrypt.cpp
+++ b/idxcrypt.cpp
@@ -779,7 +779,7 @@ int _tmain(int argc, TCHAR* argv[])
 	else
 		_tprintf(_T("Generating the encryption key..."));
 
-   if (!PBKDF2(sha256Prf, (LPBYTE) szPassword, (DWORD) strlen(szPassword), pbSalt, (DWORD) cbSalt, STRONG_ITERATIONS, pbDerivedKey, 32))
+   if (!PBKDF2(*pPrf, (LPBYTE) szPassword, (DWORD) strlen(szPassword), pbSalt, (DWORD) cbSalt, STRONG_ITERATIONS, pbDerivedKey, 32))
    {
 		if (bForDecrypt)
 			_tprintf(_T("Error!\nAn unexpected error occured while creating the decryption key (Code 0x%.8X)\n"), GetLastError());


### PR DESCRIPTION
Modify the first argument of the call of PBKDF2 function in line 782 to point to pPrf rather than sha256Prf